### PR TITLE
Fixing bug with user not filling required fields leaving review

### DIFF
--- a/components/Review.php
+++ b/components/Review.php
@@ -121,8 +121,8 @@ class Review extends \System\Classes\BaseComponent
             return Redirect::back();
         }
         catch (Exception $ex) {
-            if (Request::ajax()) throw $ex;
-            else flash()->alert($ex->getMessage())->important();
+            flash()->warning($ex->getMessage());
+            return Redirect::back()->withInput();
         }
     }
 


### PR DESCRIPTION
Fixing an issue with giant error flash when user doesn't fill all required fields when leaving a review.