### PR TITLE
Fixing problem with ratty

### DIFF
--- a/components/review/form.php
+++ b/components/review/form.php
@@ -19,7 +19,7 @@
                     class="h4"
                     data-control="star-rating"
                     data-score="<?= $customerReview ? $customerReview->quality : set_radio('rating[quality]') ?>"
-                    data-hints="<?= e(json_encode($reviewRatingHints)); ?>"
+                    data-hints="<?= e(json_encode(array_values($reviewRatingHints))); ?>"
                     data-score-name="rating[quality]"
                     <?= $customerReview ? 'data-read-only="true"' : ''; ?>
                 >
@@ -34,7 +34,7 @@
                     class="h4"
                     data-control="star-rating"
                     data-score="<?= $customerReview ? $customerReview->delivery : set_radio('rating[quality]') ?>"
-                    data-hints="<?= e(json_encode($reviewRatingHints)); ?>"
+                    data-hints="<?= e(json_encode(array_values($reviewRatingHints))); ?>"
                     data-score-name="rating[delivery]"
                     <?= $customerReview ? 'data-read-only="true"' : ''; ?>
                 >
@@ -49,7 +49,7 @@
                     class="h4"
                     data-control="star-rating"
                     data-score="<?= $customerReview ? $customerReview->service : set_radio('rating[quality]') ?>"
-                    data-hints="<?= e(json_encode($reviewRatingHints)); ?>"
+                    data-hints="<?= e(json_encode(array_values($reviewRatingHints))); ?>"
                     data-score-name="rating[service]"
                     <?= $customerReview ? 'data-read-only="true"' : ''; ?>
                 >


### PR DESCRIPTION
Small fix for ratty hints, since json_encode($reviewRatingHints) returns array with indexes, thus array_values() returns the values with numerical indexes, which causes  json_encode to return proper object