### PR TITLE
First pass at order limitation

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -1,7 +1,9 @@
 <?php namespace Igniter\Local;
 
 use Igniter\Local\Classes\Location;
+use Igniter\Local\Listeners\FilterTimeslot;
 use Illuminate\Foundation\AliasLoader;
+use Illuminate\Support\Facades\Event;
 
 class Extension extends \System\Classes\BaseExtension
 {
@@ -11,6 +13,11 @@ class Extension extends \System\Classes\BaseExtension
 
         $aliasLoader = AliasLoader::getInstance();
         $aliasLoader->alias('Location', Facades\Location::class);
+    }
+
+    public function boot()
+    {
+        Event::subscribe(FilterTimeslot::class);
     }
 
     public function registerCartConditions()

--- a/Extension.php
+++ b/Extension.php
@@ -1,7 +1,7 @@
 <?php namespace Igniter\Local;
 
 use Igniter\Local\Classes\Location;
-use Igniter\Local\Listeners\FilterTimeslot;
+use Igniter\Local\Listeners\MaxOrderPerTimeslotReached;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Facades\Event;
 
@@ -17,7 +17,7 @@ class Extension extends \System\Classes\BaseExtension
 
     public function boot()
     {
-        Event::subscribe(FilterTimeslot::class);
+        Event::subscribe(MaxOrderPerTimeslotReached::class);
     }
 
     public function registerCartConditions()

--- a/listeners/FilterTimeslot.php
+++ b/listeners/FilterTimeslot.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Igniter\Local\Listeners;
+
+use Admin\Models\Orders_model;
+use Carbon\Carbon;
+use Igniter\Flame\Location\Models\AbstractLocation;
+use Igniter\Local\Facades\Location;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class FilterTimeslot
+{
+    protected static $ordersCache;
+
+    public function subscribe(Dispatcher $dispatcher)
+    {
+        $dispatcher->listen('igniter.workingSchedule.timeslotFilter', __CLASS__.'@filterTimeslot');
+    }
+
+    public function filterTimeslot($workingSchedule, $timeslot)
+    {
+        // Skip if the working schedule is not for delivery or pickup
+        if ($workingSchedule->getType() == AbstractLocation::OPENING)
+            return;
+
+        $ordersOnThisDay = $this->getOrders($timeslot->toDateString());
+        // rest of the logic here
+    }
+
+    protected function getOrders($date)
+    {
+        if (!is_null(self::$ordersCache))
+            return self::$ordersCache;
+
+        $result = Orders_model::where('order_date', $date)
+            ->where('location_id', Location::getId())
+            ->whereIn('status_id', setting('processing_order_status', []))
+            ->select(['order_time', 'order_date'])
+            ->pluck('order_time', 'order_date');
+
+        return self::$ordersCache = $result;
+    }
+
+    public function scheduleTimeslot()
+    {
+        // cache repeated calls
+        if (!isset($this->scheduleCache)) {
+            $this->scheduleCache = [
+                'type' => '',
+                'cache' => [],
+            ];
+        }
+
+        if ($this->orderType() == $this->scheduleCache['type']) {
+            return $this->scheduleCache['cache'];
+        }
+
+//        $schedule = $this->workingSchedule($this->orderType())->getTimeslot(
+//            $this->orderTimeInterval(), null, $this->orderLeadTime()
+//        );
+
+        $self = $this;
+        $schedule->each(function ($timeslots, $dateKey) use ($self, $schedule) {
+            $limitTimeslots = $self->getModel()->getOption('limit_orders') ? $this->workingSchedule($this::OPENING)->getTimeslot(
+                $this->getModel()->getOption('limit_orders_interval'), new DateTime($dateKey), 0
+            )->toArray() : [];
+
+            $ordersOnThisDay = $self->getModel()->getOption('limit_orders') ? Orders_model::where([
+                ['location_id', '=', $this->getId()],
+                ['order_date', '=', $dateKey],
+                ['status_id', '!=', '0'],
+            ])->select(['order_date', 'order_time'])->get() : [];
+
+            $timeslots = $timeslots->filter(function ($item, $key) use ($self, $limitTimeslots, $dateKey, $ordersOnThisDay) {
+                // allow the following logic to be overwritten by extensions
+                if ($event = $self->fireSystemEvent('igniter.local.timeslotValid', [$item, $key, $dateKey])) {
+                    return $event;
+                }
+
+                if (!$self->getModel()->getOption('limit_orders')) return TRUE;
+
+                foreach ($limitTimeslots as $limitDate => $limitHoursArray) {
+                    if ($limitDate == $dateKey) {
+                        foreach ($limitHoursArray as $limitHours) {
+                            $datetime = Carbon::parse($item);
+                            $startTime = Carbon::parse($limitHours);
+                            $endTime = Carbon::parse($limitHours)->addMinutes($this->getModel()->getOption('limit_orders_interval'));
+
+                            if ($datetime->between($startTime, $endTime)) {
+                                $orderCount = $ordersOnThisDay->filter(function ($order) use ($startTime, $endTime) {
+                                    $orderTime = Carbon::createFromFormat('Y-m-d H:i:s', $order->order_date->format('Y-m-d').' '.$order->order_time);
+
+                                    return $orderTime->between(
+                                        $startTime,
+                                        $endTime
+                                    );
+                                });
+
+                                return $orderCount->count() < $self->getModel()->getOption('limit_orders_count');
+                            }
+                        }
+                    }
+                }
+
+                return FALSE;
+            });
+
+            $schedule->put($dateKey, $timeslots);
+        });
+
+        $this->scheduleCache['type'] = $this->orderType();
+        $this->scheduleCache['cache'] = $schedule;
+
+        return $schedule;
+    }
+}

--- a/listeners/FilterTimeslot.php
+++ b/listeners/FilterTimeslot.php
@@ -76,10 +76,10 @@ class FilterTimeslot
     {
         if (array_has(self::$ordersCache, $date))
             return self::$ordersCache[$date];
-
+            
         $result = Orders_model::where('order_date', $date)
             ->where('location_id', LocationFacade::getId())
-            ->whereIn('status_id', setting('processing_order_status', []))
+            ->whereIn('status_id', array_merge(setting('processing_order_status', []), setting('completed_order_status', [])))
             ->select(['order_time', 'order_date'])
             ->pluck('order_time', 'order_date');
 

--- a/listeners/FilterTimeslot.php
+++ b/listeners/FilterTimeslot.php
@@ -29,11 +29,6 @@ class FilterTimeslot
         if ($workingSchedule->getType() == AbstractLocation::OPENING)
             return;
             
-        // allow the timeslot selection logic to be overwritten by extensions
-        if ($event = $this->fireSystemEvent('igniter.local.timeslotValid', [$timeslot])) {
-            return $event;
-        }
-            
         $dateString = Carbon::parse($timeslot)->toDateString();
             
         $ordersOnThisDay = $this->getOrders($dateString);

--- a/listeners/FilterTimeslot.php
+++ b/listeners/FilterTimeslot.php
@@ -20,10 +20,10 @@ class FilterTimeslot
 
     public function subscribe(Dispatcher $dispatcher)
     {
-        $dispatcher->listen('igniter.workingSchedule.timeslotFilter', __CLASS__.'@filterTimeslot');
+        $dispatcher->listen('igniter.workingSchedule.timeslotValid', __CLASS__.'@timeslotValid');
     }
 
-    public function filterTimeslot($workingSchedule, $timeslot)
+    public function timeslotValid($workingSchedule, $timeslot)
     {
         // Skip if the working schedule is not for delivery or pickup
         if ($workingSchedule->getType() == AbstractLocation::OPENING)
@@ -50,10 +50,11 @@ class FilterTimeslot
                 );
             });
 
-            return $orderCount->count() < $location->getModel()->getOption('limit_orders_count');
+            if ($orderCount->count() >= $location->getModel()->getOption('limit_orders_count'))
+                return false;
         }
         
-        return false;
+        return;
 
     }
 

--- a/listeners/FilterTimeslot.php
+++ b/listeners/FilterTimeslot.php
@@ -4,13 +4,19 @@ namespace Igniter\Local\Listeners;
 
 use Admin\Models\Orders_model;
 use Carbon\Carbon;
+use DateTime;
 use Igniter\Flame\Location\Models\AbstractLocation;
-use Igniter\Local\Facades\Location;
+use Igniter\Local\Classes\Location;
+use Igniter\Local\Facades\Location as LocationFacade;
+use Igniter\Flame\Traits\EventEmitter;
 use Illuminate\Contracts\Events\Dispatcher;
 
 class FilterTimeslot
 {
-    protected static $ordersCache;
+    use EventEmitter;
+
+    protected static $ordersCache = [];
+    protected static $scheduleCache = [];
 
     public function subscribe(Dispatcher $dispatcher)
     {
@@ -22,95 +28,73 @@ class FilterTimeslot
         // Skip if the working schedule is not for delivery or pickup
         if ($workingSchedule->getType() == AbstractLocation::OPENING)
             return;
+            
+        // allow the timeslot selection logic to be overwritten by extensions
+        if ($event = $this->fireSystemEvent('igniter.local.timeslotValid', [$timeslot])) {
+            return $event;
+        }
+            
+        $dateString = Carbon::parse($timeslot)->toDateString();
+            
+        $ordersOnThisDay = $this->getOrders($dateString);
+                
+        $location = new Location(LocationFacade::getId());
+        $limitTimeslots = $this->getSchedule($location, $dateString);
 
-        $ordersOnThisDay = $this->getOrders($timeslot->toDateString());
-        // rest of the logic here
+        foreach ($limitTimeslots as $limitDate => $limitHoursArray)
+        {
+            if ($limitDate == $dateString)
+            {
+                foreach ($limitHoursArray as $limitHours)
+                {
+                    $datetime = Carbon::parse($timeslot);
+                    $startTime = Carbon::parse($limitHours);
+                    $endTime = Carbon::parse($limitHours)->addMinutes($location->getModel()->getOption('limit_orders_interval'));
+
+                    if ($datetime->between($startTime, $endTime))
+                    {
+                        $orderCount = $ordersOnThisDay->filter(function ($order) use ($startTime, $endTime) {
+                            $orderTime = Carbon::createFromFormat('Y-m-d H:i:s', $order->order_date->format('Y-m-d').' '.$order->order_time);
+
+                            return $orderTime->between(
+                                $startTime,
+                                $endTime
+                            );
+                        });
+
+                        return $orderCount->count() < $location->getModel()->getOption('limit_orders_count');
+                    }
+                }
+            }
+        }
+        
+        return false;
+
     }
 
     protected function getOrders($date)
     {
-        if (!is_null(self::$ordersCache))
-            return self::$ordersCache;
+        if (array_has(self::$ordersCache, $date))
+            return self::$ordersCache[$date];
 
         $result = Orders_model::where('order_date', $date)
-            ->where('location_id', Location::getId())
+            ->where('location_id', LocationFacade::getId())
             ->whereIn('status_id', setting('processing_order_status', []))
             ->select(['order_time', 'order_date'])
             ->pluck('order_time', 'order_date');
 
-        return self::$ordersCache = $result;
+        return self::$ordersCache[$date] = $result;
     }
-
-    public function scheduleTimeslot()
+    
+    protected function getSchedule($location, $date)
     {
-        // cache repeated calls
-        if (!isset($this->scheduleCache)) {
-            $this->scheduleCache = [
-                'type' => '',
-                'cache' => [],
-            ];
-        }
+        if (array_has(self::$scheduleCache, $date))
+            return self::$scheduleCache[$date];
 
-        if ($this->orderType() == $this->scheduleCache['type']) {
-            return $this->scheduleCache['cache'];
-        }
-
-//        $schedule = $this->workingSchedule($this->orderType())->getTimeslot(
-//            $this->orderTimeInterval(), null, $this->orderLeadTime()
-//        );
-
-        $self = $this;
-        $schedule->each(function ($timeslots, $dateKey) use ($self, $schedule) {
-            $limitTimeslots = $self->getModel()->getOption('limit_orders') ? $this->workingSchedule($this::OPENING)->getTimeslot(
-                $this->getModel()->getOption('limit_orders_interval'), new DateTime($dateKey), 0
-            )->toArray() : [];
-
-            $ordersOnThisDay = $self->getModel()->getOption('limit_orders') ? Orders_model::where([
-                ['location_id', '=', $this->getId()],
-                ['order_date', '=', $dateKey],
-                ['status_id', '!=', '0'],
-            ])->select(['order_date', 'order_time'])->get() : [];
-
-            $timeslots = $timeslots->filter(function ($item, $key) use ($self, $limitTimeslots, $dateKey, $ordersOnThisDay) {
-                // allow the following logic to be overwritten by extensions
-                if ($event = $self->fireSystemEvent('igniter.local.timeslotValid', [$item, $key, $dateKey])) {
-                    return $event;
-                }
-
-                if (!$self->getModel()->getOption('limit_orders')) return TRUE;
-
-                foreach ($limitTimeslots as $limitDate => $limitHoursArray) {
-                    if ($limitDate == $dateKey) {
-                        foreach ($limitHoursArray as $limitHours) {
-                            $datetime = Carbon::parse($item);
-                            $startTime = Carbon::parse($limitHours);
-                            $endTime = Carbon::parse($limitHours)->addMinutes($this->getModel()->getOption('limit_orders_interval'));
-
-                            if ($datetime->between($startTime, $endTime)) {
-                                $orderCount = $ordersOnThisDay->filter(function ($order) use ($startTime, $endTime) {
-                                    $orderTime = Carbon::createFromFormat('Y-m-d H:i:s', $order->order_date->format('Y-m-d').' '.$order->order_time);
-
-                                    return $orderTime->between(
-                                        $startTime,
-                                        $endTime
-                                    );
-                                });
-
-                                return $orderCount->count() < $self->getModel()->getOption('limit_orders_count');
-                            }
-                        }
-                    }
-                }
-
-                return FALSE;
-            });
-
-            $schedule->put($dateKey, $timeslots);
-        });
-
-        $this->scheduleCache['type'] = $this->orderType();
-        $this->scheduleCache['cache'] = $schedule;
-
-        return $schedule;
+        $schedule = $location->getModel()->getOption('limit_orders') ? $location->workingSchedule($location::OPENING)->getTimeslot(
+            $location->getModel()->getOption('limit_orders_interval'), new DateTime($date), 0
+        )->toArray() : [];
+        
+        return self::$scheduleCache[$date] = $schedule;
     }
 }

--- a/listeners/MaxOrderPerTimeslotReached.php
+++ b/listeners/MaxOrderPerTimeslotReached.php
@@ -32,23 +32,21 @@ class MaxOrderPerTimeslotReached
 
         $locationModel = LocationFacade::current();
 
-        $datetime = Carbon::parse($timeslot);
-        $startTime = Carbon::parse($timeslot)->addMinutes();
+        $startTime = Carbon::parse($timeslot);
         $endTime = Carbon::parse($timeslot)->addMinutes($locationModel->getOrderTimeInterval($workingSchedule->getType()));
 
-        if ($datetime->between($startTime, $endTime)) {
-            $orderCount = $ordersOnThisDay->filter(function ($order) use ($startTime, $endTime) {
-                $orderTime = Carbon::createFromFormat('Y-m-d H:i:s', $order->order_date->format('Y-m-d').' '.$order->order_time);
+        $orderCount = $ordersOnThisDay->filter(function ($order) use ($startTime, $endTime) {
+            $orderTime = Carbon::createFromFormat('Y-m-d H:i:s', $order->order_date->format('Y-m-d').' '.$order->order_time);
 
-                return $orderTime->between(
-                    $startTime,
-                    $endTime
-                );
-            });
+            return $orderTime->between(
+                $startTime,
+                $endTime
+            );
+        });
 
-            if ($orderCount->count() >= $locationModel->getOption('limit_orders_count'))
-                return FALSE;
-        }
+        if ($orderCount->count() >= $locationModel->getOption('limit_orders_count'))
+            return FALSE;
+
     }
 
     protected function getOrders($date)


### PR DESCRIPTION
If limit orders is enabled then check for order count in current timeslot, and remove it if limit has been reached.

This can make the front end quite laggy due to the number of queries required - I applied some caching and query reduction to work around this but its still apparent if you allow orders a number of days into the future.

Let me know your thoughts on this approach - happy to change it if you feel there is a better way.