### PR TITLE
Reviews: Allow for date range, allow text in listing view

### DIFF
--- a/language/en/default.php
+++ b/language/en/default.php
@@ -222,6 +222,7 @@ return [
         'column_author' => 'Author',
         'column_sale_id' => 'Sale ID',
         'column_sale_type' => 'Sale Type',
+        'column_text' => 'Review Text',
 
         'label_sale_type' => 'Sale Type',
         'label_sale_id' => 'Sale ID',

--- a/models/config/reviews_model.php
+++ b/models/config/reviews_model.php
@@ -24,8 +24,8 @@ $config['list']['filter'] = [
         ],
         'date' => [
             'label' => 'lang:admin::lang.text_filter_date',
-            'type' => 'date',
-            'conditions' => 'YEAR(date_added) = :year AND MONTH(date_added) = :month AND DAY(date_added) = :day',
+            'type' => 'daterange',
+            'conditions' => 'date_added >= CAST(:filtered_start AS DATE) AND date_added <= CAST(:filtered_end AS DATE)',
         ],
     ],
 ];
@@ -98,7 +98,10 @@ $config['list']['columns'] = [
         'label' => 'lang:admin::lang.column_id',
         'invisible' => TRUE,
     ],
-
+    'review_text' => [
+        'label' => 'lang:igniter.local::default.reviews.column_text',
+        'invisible' => TRUE,
+    ],
 ];
 
 $config['form']['toolbar'] = [


### PR DESCRIPTION
A couple of minor changes to reviews on the basis of what some customers have asked for.

Some other things I'd like to do, if you are happy and can guide me a bit:

1. Give a review setting option for 'chasing' reviews, ie allow the admin to specify a time in hours after which to send a follow up email asking them to review the order (link to order page should have the review form?). Can do most of this but not sure how to do the scheduling of the chase?

2. Add the average rating on the list view above the table... see attached from Resdiary to indicate how they handle it. It means when you choose a date range you can see the average scores over that period - a nice feature. If youre happy I just need to know how to insert it (i presume in the view I add some HTML, but how do I call a method on the table list items collection?)

![104130650-c2372f00-5369-11eb-87eb-4c8b9efa355f](https://user-images.githubusercontent.com/51899/104130845-e8a99a00-536a-11eb-9cf6-88a13b199f84.jpg)
