### PR TITLE
Add preview mode for disabled location

### DIFF
--- a/components/LocalBox.php
+++ b/components/LocalBox.php
@@ -244,6 +244,11 @@ class LocalBox extends \System\Classes\BaseComponent
 
     protected function redirectForceCurrent()
     {
+        if (isset($_GET['preview'])) {
+            if ($this->location->current() && $_GET['preview'] == 'true')
+                return;
+        }
+
         if ($this->location->current() && $this->location->current()->location_status == 1)
             return;
 


### PR DESCRIPTION
Allows you to preview a menu for a location that is disabled by visiting:

https://URL/SLUG/menus?preview=true

Would be nice to add a link to the admin location settings page, but this works to allow for previewing while you are setting up a new location on a production site with other locations live.