### PR TITLE
Fix comparison of distance with charge total

### DIFF
--- a/classes/CoveredArea.php
+++ b/classes/CoveredArea.php
@@ -74,8 +74,8 @@ class CoveredArea
             ->map(function ($condition) {
                 return new CoveredAreaCondition([
                     'type' => $condition['type'],
-                    'amount' => $condition['distance'],
-                    'total' => $condition['charge'],
+                    'amount' => $condition['charge'],
+                    'total' => $condition['distance'],
                 ]);
             })
             ->first(function (CoveredAreaCondition $condition) use ($distanceFromLocation) {

--- a/classes/CoveredAreaCondition.php
+++ b/classes/CoveredAreaCondition.php
@@ -47,22 +47,22 @@ class CoveredAreaCondition
 
     public function getMinTotal()
     {
-        return $this->amount;
+        return $this->total;
     }
 
     public function isValid($cartTotal)
     {
         if ($this->type === 'above' || $this->type == 'equals_or_greater')
-            return $cartTotal >= $this->amount;
+            return $cartTotal >= $this->total;
 
         if ($this->type == 'equals_or_less')
-            return $cartTotal <= $this->amount;
+            return $cartTotal <= $this->total;
 
         if ($this->type == 'greater')
-            return $cartTotal > $this->amount;
+            return $cartTotal > $this->total;
 
         if ($this->type === 'below' || $this->type == 'less')
-            return $cartTotal < $this->amount;
+            return $cartTotal < $this->total;
 
         return TRUE;
     }

--- a/classes/CoveredAreaCondition.php
+++ b/classes/CoveredAreaCondition.php
@@ -53,16 +53,16 @@ class CoveredAreaCondition
     public function isValid($cartTotal)
     {
         if ($this->type === 'above' || $this->type == 'equals_or_greater')
-            return $cartTotal >= $this->total;
+            return $cartTotal >= $this->amount;
 
         if ($this->type == 'equals_or_less')
-            return $cartTotal <= $this->total;
+            return $cartTotal <= $this->amount;
 
         if ($this->type == 'greater')
-            return $cartTotal > $this->total;
+            return $cartTotal > $this->amount;
 
         if ($this->type === 'below' || $this->type == 'less')
-            return $cartTotal < $this->total;
+            return $cartTotal < $this->amount;
 
         return TRUE;
     }


### PR DESCRIPTION
On this line we are setting the amount to be the distance
https://github.com/tastyigniter/ti-ext-local/blob/master/classes/CoveredArea.php#L77

Then calling line 82:
return $condition->isValid($distanceFromLocation);

However, we are comparing the distance with the amount to be charged "total" instead of the distance of the condition "amount"