### PR TITLE
Fix: defaultOrderType can be disabled type

### DIFF
--- a/classes/Location.php
+++ b/classes/Location.php
@@ -350,11 +350,11 @@ class Location extends Manager
         return $orderType->getSchedule()->isOpenAt($timestamp);
     }
 
-    public function checkNoOrderTypeAvailable($timestamp = null, $orderTypeCode = null)
+    public function checkNoOrderTypeAvailable()
     {
-        return is_null($this->getOrderTypes()->first(function ($orderType) {
+        return $this->getOrderTypes()->filter(function ($orderType) {
             return !$orderType->isDisabled();
-        }));
+        })->isEmpty();
     }
 
     public function hasAsapSchedule()

--- a/classes/Location.php
+++ b/classes/Location.php
@@ -123,7 +123,20 @@ class Location extends Manager
 
     public function orderType()
     {
-        return $this->getSession('orderType', Locations_model::DELIVERY);
+        return $this->getSession('orderType', $this->defaultOrderType());
+    }
+
+    public function defaultOrderType()
+    {
+        foreach ($this->getOrderTypes() as $orderType){
+            if(!$orderType->isDisabled()){
+                return $orderType->getCode();
+            }
+        }
+
+        // TODO: handle corner case for all order type disabled.
+        // If all order type disabled, return Delivery.
+        return Locations_model::DELIVERY;
     }
 
     /**

--- a/classes/Location.php
+++ b/classes/Location.php
@@ -126,19 +126,6 @@ class Location extends Manager
         return $this->getSession('orderType', $this->defaultOrderType());
     }
 
-    public function defaultOrderType()
-    {
-        foreach ($this->getOrderTypes() as $orderType){
-            if(!$orderType->isDisabled()){
-                return $orderType->getCode();
-            }
-        }
-
-        // TODO: handle corner case for all order type disabled.
-        // If all order type disabled, return Delivery.
-        return Locations_model::DELIVERY;
-    }
-
     /**
      * @return \Igniter\Flame\Geolite\Model\Location
      */

--- a/classes/Location.php
+++ b/classes/Location.php
@@ -123,7 +123,7 @@ class Location extends Manager
 
     public function orderType()
     {
-        return $this->getSession('orderType', $this->defaultOrderType());
+        return $this->getSession('orderType', Locations_model::DELIVERY);
     }
 
     /**

--- a/classes/Location.php
+++ b/classes/Location.php
@@ -350,6 +350,13 @@ class Location extends Manager
         return $orderType->getSchedule()->isOpenAt($timestamp);
     }
 
+    public function checkNoOrderTypeAvailable($timestamp = null, $orderTypeCode = null)
+    {
+        return is_null($this->getOrderTypes()->first(function ($orderType) {
+            return !$orderType->isDisabled();
+        }));
+    }
+
     public function hasAsapSchedule()
     {
         if ($this->getOrderType()->getMinimumFutureDays())

--- a/components/LocalBox.php
+++ b/components/LocalBox.php
@@ -48,13 +48,6 @@ class LocalBox extends \System\Classes\BaseComponent
                 'default' => 'home',
                 'validationRule' => 'required|regex:/^[a-z0-9\-_\/]+$/i',
             ],
-            'defaultOrderType' => [
-                'label' => 'lang:igniter.local::default.label_default_order_type',
-                'type' => 'select',
-                'default' => Locations_model::DELIVERY,
-                'options' => [Locations_model::class, 'getOrderTypeOptions'],
-                'validationRule' => 'required|alpha_dash',
-            ],
             'showLocalThumb' => [
                 'label' => 'lang:igniter.local::default.label_show_local_image',
                 'type' => 'switch',
@@ -259,7 +252,7 @@ class LocalBox extends \System\Classes\BaseComponent
         if ($sessionOrderType && $this->location->hasOrderType($sessionOrderType))
             return;
 
-        $defaultOrderType = $this->property('defaultOrderType');
+        $defaultOrderType = $this->location->defaultOrderType();
         if (!$this->location->hasOrderType($defaultOrderType))
             $defaultOrderType = key(Locations_model::getOrderTypeOptions()->all());
 

--- a/components/LocalBox.php
+++ b/components/LocalBox.php
@@ -3,6 +3,7 @@
 namespace Igniter\Local\Components;
 
 use Admin\Facades\AdminAuth;
+use Admin\Models\Locations_model;
 use Carbon\Carbon;
 use DateTime;
 use Exception;
@@ -46,6 +47,13 @@ class LocalBox extends \System\Classes\BaseComponent
                 'options' => [static::class, 'getThemePageOptions'],
                 'default' => 'home',
                 'validationRule' => 'required|regex:/^[a-z0-9\-_\/]+$/i',
+            ],
+            'defaultOrderType' => [
+                'label' => 'lang:igniter.local::default.label_default_order_type',
+                'type' => 'select',
+                'default' => Locations_model::DELIVERY,
+                'options' => [Locations_model::class, 'getOrderTypeOptions'],
+                'validationRule' => 'required|alpha_dash',
             ],
             'showLocalThumb' => [
                 'label' => 'lang:igniter.local::default.label_show_local_image',
@@ -255,7 +263,7 @@ class LocalBox extends \System\Classes\BaseComponent
         if ($sessionOrderType && $this->location->hasOrderType($sessionOrderType))
             return;
 
-        $defaultOrderType = $this->location->defaultOrderType();
+        $defaultOrderType = $this->property('defaultOrderType');
         if (!$this->location->hasOrderType($defaultOrderType)) {
             $defaultOrderType = optional($this->location->getOrderTypes()->first(function ($orderType) {
                 return !$orderType->isDisabled();

--- a/components/LocalBox.php
+++ b/components/LocalBox.php
@@ -96,6 +96,8 @@ class LocalBox extends \System\Classes\BaseComponent
         $this->addJs('js/local.js', 'local-js');
         $this->addJs('js/local.timeslot.js', 'local-timeslot-js');
 
+        $this->updateCurrentOrderType();
+
         if ($this->currentLocationIsDisabled()) {
             flash()->error(lang('igniter.local::default.alert_location_required'));
 
@@ -248,7 +250,7 @@ class LocalBox extends \System\Classes\BaseComponent
             return true;
     }
 
-    protected function updateAndCheckCurrentOrderTypeIsInActive()
+    protected function updateCurrentOrderType()
     {
         if (!$this->location->current())
             return;
@@ -264,10 +266,8 @@ class LocalBox extends \System\Classes\BaseComponent
             }))->getCode();
         }
 
-        if (!$defaultOrderType)
-            return true;
-
-        $this->location->updateOrderType($defaultOrderType);
+        if ($defaultOrderType)
+            $this->location->updateOrderType($defaultOrderType);
     }
 
     protected function checkAdminAccess()

--- a/components/LocalBox.php
+++ b/components/LocalBox.php
@@ -102,12 +102,6 @@ class LocalBox extends \System\Classes\BaseComponent
             return Redirect::to($this->controller->pageUrl($this->property('redirect')));
         }
 
-        if ($this->updateAndCheckCurrentOrderTypeIsInActive()) {
-            flash()->error(lang('igniter.local::default.alert_order_type_required'));
-
-            return Redirect::to($this->controller->pageUrl($this->property('redirect')));
-        }
-
         $this->prepareVars();
     }
 

--- a/components/localbox/control.blade.php
+++ b/components/localbox/control.blade.php
@@ -1,7 +1,7 @@
 @if ($location->checkNoOrderTypeAvailable())
-        <label
-            class="btn btn-light w-100 active"
-        ><b>@lang('igniter.local::default.alert_order_type_required')</b></label>
+    <label
+        class="btn btn-light w-100 active"
+    ><b>@lang('igniter.local::default.alert_order_type_required')</b></label>
 @else
     @if (count($locationOrderTypes) <= $__SELF__->property('maxOrderTypeButtons', 2))
         <div

--- a/components/localbox/control.blade.php
+++ b/components/localbox/control.blade.php
@@ -1,55 +1,61 @@
-@if (count($locationOrderTypes) <= $__SELF__->property('maxOrderTypeButtons', 2))
-    <div
-        class="btn-group btn-group-toggle w-100 text-center"
-        data-control="order-type-toggle"
-        data-handler="{{ $orderTypeEventHandler }}"
-    >
-        @foreach($locationOrderTypes as $orderType)
-            @continue($orderType->isDisabled())
-            <input
-                id="btn-check-{{$orderType->getCode()}}"
-                type="radio"
-                name="order_type"
-                class="btn-check"
-                value="{{ $orderType->getCode() }}"
-                {!! $orderType->isActive() ? 'checked="checked"' : '' !!}
-            />
-            <label
-                for="btn-check-{{$orderType->getCode()}}"
-                class="btn btn-light w-50 {{ $orderType->isActive() ? 'active' : '' }}"
-            >@partial('@control_info', ['orderType' => $orderType])</label>
-        @endforeach
-    </div>
+@if ($location->checkNoOrderTypeAvailable())
+        <label
+            class="btn btn-light w-100 active"
+        ><b>@lang('igniter.local::default.alert_order_type_required')</b></label>
 @else
-    <div
-        class="dropdown"
-        data-control="order-type-toggle"
-        data-handler="{{ $orderTypeEventHandler }}"
-    >
-        <button
-            class="btn btn-light btn-block dropdown-toggle"
-            type="button"
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
+    @if (count($locationOrderTypes) <= $__SELF__->property('maxOrderTypeButtons', 2))
+        <div
+            class="btn-group btn-group-toggle w-100 text-center"
+            data-control="order-type-toggle"
+            data-handler="{{ $orderTypeEventHandler }}"
         >
-            @partial('@control_info', ['orderType' => $location->getOrderType()])
-        </button>
-        <div class="dropdown-menu w-100" aria-labelledby="dropdownMenuButton">
             @foreach($locationOrderTypes as $orderType)
                 @continue($orderType->isDisabled())
-                <a
-                    role="button"
-                    class="dropdown-item text-center {{ $orderType->isActive() ? 'active' : '' }}"
-                    data-order-type-code="{{ $orderType->getCode() }}"
-                >
-                    @partial('@control_info', ['orderType' => $orderType])
-                </a>
+                <input
+                    id="btn-check-{{$orderType->getCode()}}"
+                    type="radio"
+                    name="order_type"
+                    class="btn-check"
+                    value="{{ $orderType->getCode() }}"
+                    {!! $orderType->isActive() ? 'checked="checked"' : '' !!}
+                />
+                <label
+                    for="btn-check-{{$orderType->getCode()}}"
+                    class="btn btn-light w-50 {{ $orderType->isActive() ? 'active' : '' }}"
+                >@partial('@control_info', ['orderType' => $orderType])</label>
             @endforeach
         </div>
-    </div>
-@endif
-@if ($minOrderTotal = $location->minimumOrderTotal())
-    <p class="text-muted text-center my-2">
-        @lang('igniter.local::default.text_min_total'): {{ currency_format($minOrderTotal) }}
-    </p>
+    @else
+        <div
+            class="dropdown"
+            data-control="order-type-toggle"
+            data-handler="{{ $orderTypeEventHandler }}"
+        >
+            <button
+                class="btn btn-light btn-block dropdown-toggle"
+                type="button"
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
+            >
+                @partial('@control_info', ['orderType' => $location->getOrderType()])
+            </button>
+            <div class="dropdown-menu w-100" aria-labelledby="dropdownMenuButton">
+                @foreach($locationOrderTypes as $orderType)
+                    @continue($orderType->isDisabled())
+                    <a
+                        role="button"
+                        class="dropdown-item text-center {{ $orderType->isActive() ? 'active' : '' }}"
+                        data-order-type-code="{{ $orderType->getCode() }}"
+                    >
+                        @partial('@control_info', ['orderType' => $orderType])
+                    </a>
+                @endforeach
+            </div>
+        </div>
+    @endif
+    @if ($minOrderTotal = $location->minimumOrderTotal())
+        <p class="text-muted text-center my-2">
+            @lang('igniter.local::default.text_min_total'): {{ currency_format($minOrderTotal) }}
+        </p>
+    @endif
 @endif

--- a/components/localbox/timeslot.blade.php
+++ b/components/localbox/timeslot.blade.php
@@ -2,7 +2,7 @@
     $orderDateTime = $location->orderDateTime();
     $orderTimeIsAsap = $location->orderTimeIsAsap();
 @endphp
-@if (!$location->checkOrderTime())
+@if (!$location->checkOrderTime() || $location->checkNoOrderTypeAvailable())
     <button
         class="btn btn-light btn-timepicker btn-block text-truncate active"
         id="orderTimePicker"

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,7 @@ permalink: /
 | ------------------------ | ------------------------ | ------------- | ------------- |
 | paramFrom           | URL routing code used for determining the location slug           | location        | location         |
 | redirect           | Page name to redirect to when location is not loaded            | home        | home         |
+| defaultOrderType           | The default selected order type            | true/false        | false         |
 | showLocalThumb           | Show/hide the current location's thumb            | true/false        | false         |
 | locationThumbWidth        | Location thumb Height        |        80           |      80    |
 | locationThumbHeight       | Location thumb Width     |        80           |      80    |

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,6 @@ permalink: /
 | ------------------------ | ------------------------ | ------------- | ------------- |
 | paramFrom           | URL routing code used for determining the location slug           | location        | location         |
 | redirect           | Page name to redirect to when location is not loaded            | home        | home         |
-| defaultOrderType           | The default selected order type            | true/false        | false         |
 | showLocalThumb           | Show/hide the current location's thumb            | true/false        | false         |
 | locationThumbWidth        | Location thumb Height        |        80           |      80    |
 | locationThumbHeight       | Location thumb Width     |        80           |      80    |

--- a/language/en/default.php
+++ b/language/en/default.php
@@ -141,6 +141,7 @@ return [
     'alert_invalid_search_query' => 'We couldn\'t locate the entered address or postcode, please enter a valid address or postcode.',
     'alert_no_found_restaurant' => 'We do not have any local restaurant near you.',
     'alert_location_required' => 'No location found or selected',
+    'alert_order_type_required' => 'Sorry, there\'s no active order type for this location',
     'alert_order_is_unavailable' => 'This restaurant is unavailable to take %s orders at the selected time.',
     'alert_slot_time_required' => 'Please select a slot time.',
     'alert_slot_date_required' => 'Please select a slot date.',

--- a/language/en/default.php
+++ b/language/en/default.php
@@ -141,7 +141,7 @@ return [
     'alert_invalid_search_query' => 'We couldn\'t locate the entered address or postcode, please enter a valid address or postcode.',
     'alert_no_found_restaurant' => 'We do not have any local restaurant near you.',
     'alert_location_required' => 'No location found or selected',
-    'alert_order_type_required' => 'Sorry, there\'s no active order type for this location',
+    'alert_order_type_required' => 'There\'s no active online ordering option for this location',
     'alert_order_is_unavailable' => 'This restaurant is unavailable to take %s orders at the selected time.',
     'alert_slot_time_required' => 'Please select a slot time.',
     'alert_slot_date_required' => 'Please select a slot date.',


### PR DESCRIPTION
### The problem:
1. log in as an Admin user, and disable Delivery for a location.
2. Open the menu page of this location, will see the Pickup option is not highlighted.
3. Try to add an item to the cart, will receive an error message: "Delivery is not available".

Though the solution to this problem is relatively easy, just manually click on the "Pickup" option on the page, the behavior is indeed very confusing for innocent customers.


### Future work
There is a TODO comment in Location.php, for the corner case that all order types are disabled. I currently fall back this corner case to the original behavior, which is a menu page with an invisible delivery option selected. However, the ideal solution to this case would be to display the whole menu page as "Sorry, there's no active order type for this location".