### PR TITLE
Fix Order type selection component disappear in responsive

### DIFF
--- a/components/localbox/container.blade.php
+++ b/components/localbox/container.blade.php
@@ -13,7 +13,7 @@
 
     @partial($__SELF__.'::default')
 
-    <div class="card mt-1 d-block d-sm-none">
+    <div class="card mt-1 d-block d-lg-none">
         <div class="card-body">
             <div class="local-timeslot mb-3">
                 @partial('@timeslot')


### PR DESCRIPTION
### The problem
At a certain resolution, the Order type selection component will be disappeared.
![image](https://user-images.githubusercontent.com/12481493/187928516-2a731dc9-dc79-43ba-b166-97d7a80ca2e8.png)

### The simple fix
Because the `affix-cart panel` appears using `d-lg-block`, while the `card` will disappear with `d-sm-none`. If the resolution falls in the gap between sm and lg, none of the components will show up.