### PR TITLE
Fix: cannot import menu category field

### DIFF
--- a/models/MenuImport.php
+++ b/models/MenuImport.php
@@ -94,7 +94,7 @@ class MenuImport extends ImportModel
             }
             else {
                 $newCategory = Categories_model::firstOrCreate(['name' => $name]);
-                $ids[] = $this->categoryNameCache[$name] = $newCategory->id;
+                $ids[] = $this->categoryNameCache[$name] = $newCategory->category_id;
             }
         }
 


### PR DESCRIPTION
A simple fix for the problem that import/export extension cannot apply the "Category" field to database.

The root cause the `$newCategory->id` will always be `null` and should use `$newCategory->category_id` instead.