### PR TITLE
Display location description

### DIFF
--- a/components/localbox/box_one.blade.php
+++ b/components/localbox/box_one.blade.php
@@ -20,3 +20,8 @@
         <span class="text-muted">{!! format_address($locationCurrent->getAddress(), FALSE) !!}</span>
     </dd>
 </dl>
+<div class="card">
+    <div class="card-header">
+        <?=$locationCurrent->description;?>
+    </div>
+</div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12481493/190476572-5b78580b-7c0a-43b7-91b1-793bca94ed4c.png)

There is already a `description` field in location settings but seems like this field never gets implemented to display to users. The current look in this PR may not be very pretty and I would be grateful if there's any other better design. Thanks!