### PR TITLE
Bring back chevron on menu category

### DIFF
--- a/components/menu/grouped.blade.php
+++ b/components/menu/grouped.blade.php
@@ -13,7 +13,7 @@
                         data-bs-target="#category-{{ $menuCategoryAlias }}-collapse"
                         aria-expanded="false"
                         aria-controls="category-{{ $menuCategoryAlias }}-heading"
-                    >{{ $menuCategory->name }}<span class="collapse-toggle text-muted pull-right"></span></h4>
+                    >{{ $menuCategory->name }}<i class="fa fa-chevron-down pull-right"></i></h4>
                 </div>
                 <div
                     id="category-{{ $menuCategoryAlias }}-collapse"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/12481493/193155655-10927b4d-c176-46cb-8cbe-fa0a21da0af7.png)

### Why make this change
The chevron on the menu category was removed on an April commit on the orange theme for upgrading to bootstrap 5. However, the foldable category title is not indicating the user to click on it for fold/unfold. I had some people complaining "some categories are empty" because they are not aware the category title is actually folded and also don't know it is clickable.