### PR TITLE
Bug: fixed the error message not visible proper when deleting menu items tied to locations where user doesnt have access to one

### DIFF
--- a/src/Models/Concerns/Locationable.php
+++ b/src/Models/Concerns/Locationable.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Igniter\Local\Models\Concerns;
 
 use Igniter\Flame\Exception\SystemException;
+use Igniter\Flame\Exception\FlashException;
 use Igniter\Flame\Support\Facades\Igniter;
 use Igniter\Local\Models\Scopes\LocationableScope;
 use Igniter\User\Facades\AdminAuth;
@@ -48,7 +49,7 @@ trait Locationable
         $locationable = $this->getLocationableRelationObject();
 
         if (Igniter::runningInAdmin() && !AdminAuth::isSuperUser() && $locationable->count()) {
-            throw new SystemException(lang('igniter::admin.alert_warning_locationable_delete'));
+            throw new FlashException(lang('igniter::admin.alert_warning_locationable_delete'));
         }
 
         $locationable->detach();


### PR DESCRIPTION
It throws system exception in flash message though error message is correct so i have switched it to flash exception, so the message is correctly visible