### PR TITLE
Enforce ASAP/Later restriction in Location::checkOrderTime

### DIFF
--- a/src/Classes/Location.php
+++ b/src/Classes/Location.php
@@ -340,7 +340,7 @@ class Location
         return Carbon::parse($this->getOrderType()->getSchedule()->getCloseTime());
     }
 
-    public function checkOrderTime($timestamp = null, $orderTypeCode = null)
+    public function checkOrderTime($timestamp = null, $orderTypeCode = null, ?bool $isAsap = null)
     {
         if (is_null($timestamp)) {
             $timestamp = $this->orderDateTime();
@@ -355,6 +355,10 @@ class Location
         }
 
         $orderType = $this->getOrderType($orderTypeCode);
+
+        if (!$orderType->allowsBookingAt($isAsap)) {
+            return false;
+        }
 
         if (!$orderType->getFutureDays() && $this->isClosed()) {
             return false;

--- a/src/Facades/Location.php
+++ b/src/Facades/Location.php
@@ -49,7 +49,7 @@ use Override;
  * @method static void openTime(void $type = null, void $format = null)
  * @method static void closeTime(void $type = null, void $format = null)
  * @method static void lastOrderTime()
- * @method static bool checkOrderTime(void $timestamp = null, void $orderTypeCode = null)
+ * @method static bool checkOrderTime(void $timestamp = null, void $orderTypeCode = null, ?bool $isAsap = null)
  * @method static Carbon orderDateTime()
  * @method static bool orderTimeIsAsap()
  * @method static bool hasAsapSchedule()

--- a/tests/Classes/LocationTest.php
+++ b/tests/Classes/LocationTest.php
@@ -335,6 +335,7 @@ it('checks order time returns false when no future days and location is closed',
     $orderType = mock(AbstractOrderType::class);
     $location->shouldReceive('getOrderType')->andReturn($orderType);
     $location->shouldReceive('isClosed')->andReturnTrue();
+    $orderType->shouldReceive('allowsBookingAt')->andReturnTrue();
     $orderType->shouldReceive('getFutureDays')->andReturnFalse();
 
     expect($location->checkOrderTime(now()->toDateTimeString()))->toBeFalse();
@@ -345,10 +346,33 @@ it('checks order time returns false when location is closed in future dates', fu
     $orderType = mock(AbstractOrderType::class);
     $location->shouldReceive('getOrderType')->andReturn($orderType);
     $location->shouldReceive('isClosed')->andReturnFalse();
+    $orderType->shouldReceive('allowsBookingAt')->andReturnTrue();
     $orderType->shouldReceive('getMinimumFutureDays')->andReturn(5);
     $orderType->shouldReceive('getFutureDays')->andReturn(10);
 
     expect($location->checkOrderTime(now()->addDay()))->toBeFalse();
+});
+
+it('checks order time returns false when order type rejects the ASAP/Later choice', function(): void {
+    $location = mock(Location::class)->makePartial();
+    $orderType = mock(AbstractOrderType::class);
+    $location->shouldReceive('getOrderType')->andReturn($orderType);
+    $orderType->shouldReceive('allowsBookingAt')->with(false)->andReturnFalse();
+
+    expect($location->checkOrderTime(now()->addHour(), null, false))->toBeFalse();
+});
+
+it('checks order time passes the isAsap flag through to the order type', function(): void {
+    $location = mock(Location::class)->makePartial();
+    $orderType = mock(AbstractOrderType::class);
+    $location->shouldReceive('getOrderType')->andReturn($orderType);
+    $orderType->shouldReceive('allowsBookingAt')->with(true)->once()->andReturnTrue();
+    $orderType->shouldReceive('getFutureDays')->andReturn(10);
+    $orderType->shouldReceive('getMinimumFutureDays')->andReturn(0);
+    $orderType->shouldReceive('getSchedule->isOpenAt')->andReturnTrue();
+    $location->shouldReceive('isClosed')->andReturnFalse();
+
+    expect($location->checkOrderTime(now()->addHour(), null, true))->toBeTrue();
 });
 
 it('orderTimeIsAsap returns first schedule timeslot when session date time is in the past', function(): void {


### PR DESCRIPTION
## Summary

Adds an optional `?bool $isAsap = null` argument to `Location::checkOrderTime()` and delegates the ASAP_ONLY / LATER_ONLY policy check to the order type via `AbstractOrderType::allowsBookingAt()`.

## Why

`checkOrderTime()` is documented and used as the validation gate for a customer's chosen booking time — but today it only validates that the timestamp falls inside an open schedule window. It does **not** enforce the order type's `getScheduleRestriction()`. As a result, a theme can hand it a valid open-window timestamp under the Later branch even when the order type is configured `ASAP_ONLY`, and the booking passes.

Before:
```php
// Orange theme's FulfillmentModal::updateTimeslot()
$timeSlotDateTime = $this->isAsap ? now() : make_carbon(...);
$this->location->checkOrderTime($timeSlotDateTime); // returns true even under ASAP_ONLY
```

After:
```php
$this->location->checkOrderTime($timeSlotDateTime, null, $this->isAsap);
```

The new parameter is optional and defaults to `null` so existing callers (admin order edits, API endpoints, other themes that don't have a user-supplied choice) continue to work unchanged — `allowsBookingAt(null)` returns `true`.

## Dependency

Requires `tastyigniter/ti-ext-cart#127` to be merged/released first — that PR adds `AbstractOrderType::allowsBookingAt()`.

## Test plan

- [x] `it checks order time returns false when order type rejects the ASAP/Later choice` — new branch returns false.
- [x] `it checks order time passes the isAsap flag through to the order type` — confirms delegation.
- [x] Existing `checks order time…` cases updated to mock `allowsBookingAt` returning true so they still cover their original branches.

## Follow-up

A companion PR will be filed against `tastyigniter/ti-theme-orange` to pass `\$isAsap` through and hide the inapplicable radio button in the fulfillment modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)