### PR TITLE
fix(WorkingSchedule): prevent date window expanding past maxDays when schedule closes early

### DIFF
--- a/src/Classes/WorkingSchedule.php
+++ b/src/Classes/WorkingSchedule.php
@@ -233,13 +233,14 @@ class WorkingSchedule
             $dateTime = clone $dateTime;
         }
 
-        $nextCloseAt = $this->forDate($dateTime)->nextCloseAt(
-            WorkingTime::fromDateTime($dateTime),
-        );
-
         if (!$this->hasPeriod()) {
             return null;
         }
+
+        $forDate = $this->forDate($dateTime);
+        $nextCloseAt = $forDate->isEmpty()
+            ? false
+            : $forDate->nextCloseAt(WorkingTime::fromDateTime($dateTime));
 
         while ($nextCloseAt === false) {
             $dateTime = $dateTime->modify('+1 day')->setTime(0, 0);
@@ -451,8 +452,8 @@ class WorkingSchedule
         }
 
         $nextEndDate = $this->nextCloseAt($endDate->copy()->subDay());
-        if ($nextEndDate->lt($dateTime)) {
-            $endDate = $nextEndDate->addDay();
+        if ($nextEndDate !== null && Carbon::instance($nextEndDate)->startOfDay()->lt(Carbon::instance($dateTime)->startOfDay())) {
+            $endDate = Carbon::instance($nextEndDate)->addDay();
         }
 
         return new DatePeriod($startDate, new DateInterval('P1D'), $endDate);


### PR DESCRIPTION
## Summary

- When a schedule has an early close time (e.g. 07:00) and the current time is past that close time, `createPeriodForDays()` was incorrectly extending the date window by one day. This caused dates beyond `maxDays` to appear in the fulfillment modal date picker — including days that should be disabled (skipped days like a closed Wednesday).
- The root cause was a full timestamp comparison (`$nextEndDate->lt($dateTime)`) instead of a date-only comparison. When today's close time (e.g. 07:00) had already passed, `nextCloseAt()` would return a time earlier than `now()`, triggering the extension incorrectly.
- Additionally, the initial call in `nextCloseAt()` did not guard against empty/skipped periods (unlike the `while` loop body which already did), causing inconsistent behaviour when the starting day is a closed day.

## Changes

- **`nextCloseAt()`**: moved `hasPeriod()` guard before the period lookup and added `isEmpty()` check on the initial `forDate()` call, consistent with the `while` loop body.
- **`createPeriodForDays()`**: changed timestamp comparison to a date-only comparison (`startOfDay()`) so the end boundary is only extended when `$nextEndDate` is genuinely from a past **date**, not just a past time-of-day. Also added a `null` guard for schedules with no periods.

## Test plan

- [ ] Set schedule close time to an early time (e.g. 07:00), disable future ordering, and open the fulfillment modal after 07:00 — no dates should appear
- [ ] Skip a day (e.g. Wednesday) with future ordering enabled — only Wednesday should be excluded, all other days within `maxDays` should appear
- [ ] Enable future ordering with `minDays=0, maxDays=5` — date picker should show today through 5 days ahead, minus any skipped days

🤖 Generated with [Claude Code](https://claude.com/claude-code)